### PR TITLE
Update dependencies to allow usage of stdlib 0.48.0 and newer

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "handles"
-version = "4.0.1"
+version = "5.0.0"
 
 description = "Handles is a templating language written in pure Gleam. Heavily inspired by Mustache and Handlebars.js"
 licences = ["MIT"]
@@ -7,7 +7,8 @@ repository = { type = "github", user = "olian04", repo = "gleam_handles" }
 gleam = ">= 1.0.0"
 
 [dependencies]
-gleam_stdlib = ">= 0.38.0 and < 1.0.0"
+gleam_stdlib = ">= 0.48.0 and < 1.0.0"
+gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.1.2 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleam_stdlib", version = "0.56.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "7C5169F4DA62BB5CD1FC3EBE40C63415FDE1AAA7E5BD13F2B047FF973B571568" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.38.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.48.0 and < 1.0.0" }
+gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.1.2 and < 2.0.0" }

--- a/src/handles.gleam
+++ b/src/handles.gleam
@@ -2,7 +2,7 @@ import gleam/dict
 import gleam/list
 import gleam/pair
 import gleam/result
-import gleam/string_builder
+import gleam/string_tree
 import handles/ctx
 import handles/error
 import handles/internal/engine
@@ -20,7 +20,7 @@ fn unwrap_template(template: Template) -> List(parser.AST) {
 
 pub fn prepare(template: String) -> Result(Template, error.TokenizerError) {
   tokenizer.run(template)
-  |> result.try(parser.run(_))
+  |> result.try(parser.run)
   |> result.map(Template)
 }
 
@@ -28,7 +28,7 @@ pub fn run(
   template: Template,
   ctx: ctx.Value,
   partials: List(#(String, Template)),
-) -> Result(string_builder.StringBuilder, error.RuntimeError) {
+) -> Result(string_tree.StringTree, error.RuntimeError) {
   partials
   |> list.map(pair.map_second(_, unwrap_template))
   |> dict.from_list

--- a/src/handles/format.gleam
+++ b/src/handles/format.gleam
@@ -21,13 +21,13 @@ fn resolve_position(
           case char {
             "\n" ->
               resolve_position(
-                string.drop_left(input, 1),
+                string.drop_start(input, 1),
                 target_index,
                 Position(index + 1, row + 1, 0),
               )
             _ ->
               resolve_position(
-                string.drop_left(input, 1),
+                string.drop_start(input, 1),
                 target_index,
                 Position(index + 1, row, col + 1),
               )

--- a/src/handles/internal/engine.gleam
+++ b/src/handles/internal/engine.gleam
@@ -1,6 +1,6 @@
 import gleam/dict
 import gleam/list
-import gleam/string_builder
+import gleam/string_tree
 import handles/ctx
 import handles/error
 import handles/internal/block
@@ -16,8 +16,8 @@ fn eval(
   actions: List(Action),
   ctx: ctx.Value,
   partials: dict.Dict(String, List(parser.AST)),
-  builder: string_builder.StringBuilder,
-) -> Result(string_builder.StringBuilder, error.RuntimeError) {
+  builder: string_tree.StringTree,
+) -> Result(string_tree.StringTree, error.RuntimeError) {
   case actions {
     [] -> Ok(builder)
     [SetCtx(new_ctx), ..rest_action] ->
@@ -25,13 +25,13 @@ fn eval(
     [RunAst([]), ..rest_action] -> eval(rest_action, ctx, partials, builder)
     [RunAst([parser.Constant(_, value), ..rest_ast]), ..rest_action] ->
       [RunAst(rest_ast), ..rest_action]
-      |> eval(ctx, partials, string_builder.append(builder, value))
+      |> eval(ctx, partials, string_tree.append(builder, value))
     [RunAst([parser.Property(index, path), ..rest_ast]), ..rest_action] ->
       case ctx_utils.get_property(path, ctx, index) {
         Error(err) -> Error(err)
         Ok(value) ->
           [RunAst(rest_ast), ..rest_action]
-          |> eval(ctx, partials, string_builder.append(builder, value))
+          |> eval(ctx, partials, string_tree.append(builder, value))
       }
     [RunAst([parser.Partial(index, id, path), ..rest_ast]), ..rest_action] ->
       case dict.get(partials, id) {
@@ -109,6 +109,6 @@ pub fn run(
   ast: List(parser.AST),
   ctx: ctx.Value,
   partials: dict.Dict(String, List(parser.AST)),
-) -> Result(string_builder.StringBuilder, error.RuntimeError) {
-  eval([RunAst(ast)], ctx, partials, string_builder.new())
+) -> Result(string_tree.StringTree, error.RuntimeError) {
+  eval([RunAst(ast)], ctx, partials, string_tree.new())
 }

--- a/test/api_tests/each_test.gleam
+++ b/test/api_tests/each_test.gleam
@@ -1,4 +1,4 @@
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles
 import handles/ctx
@@ -11,7 +11,7 @@ pub fn each_test() {
     [],
   )
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("yesyesyes")
 }
 
@@ -20,7 +20,7 @@ pub fn each_empty_test() {
   |> should.be_ok
   |> handles.run(ctx.Dict([ctx.Prop("prop", ctx.List([]))]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("")
 }
 
@@ -29,6 +29,6 @@ pub fn each_current_context_test() {
   |> should.be_ok
   |> handles.run(ctx.List([ctx.Int(1), ctx.Int(2), ctx.Int(3)]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("yesyesyes")
 }

--- a/test/api_tests/if_test.gleam
+++ b/test/api_tests/if_test.gleam
@@ -1,4 +1,4 @@
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles
 import handles/ctx
@@ -8,7 +8,7 @@ pub fn if_truthy_test() {
   |> should.be_ok
   |> handles.run(ctx.Dict([ctx.Prop("prop", ctx.Bool(True))]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("yes")
 }
 
@@ -17,7 +17,7 @@ pub fn if_falsy_test() {
   |> should.be_ok
   |> handles.run(ctx.Dict([ctx.Prop("prop", ctx.Bool(False))]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("")
 }
 
@@ -26,6 +26,6 @@ pub fn if_current_context_test() {
   |> should.be_ok
   |> handles.run(ctx.Bool(True), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("yes")
 }

--- a/test/api_tests/partial_test.gleam
+++ b/test/api_tests/partial_test.gleam
@@ -1,4 +1,4 @@
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles
 import handles/ctx
@@ -14,7 +14,7 @@ pub fn partial_test() {
     #("hello", hello_template),
   ])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("Hello Oliver!")
 }
 
@@ -34,7 +34,7 @@ pub fn partial_multiple_test() {
     [#("hello", hello_template)],
   )
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("Hello Knatte! Hello Fnatte! Hello Tjatte!")
 }
 
@@ -54,6 +54,6 @@ pub fn partial_nested_test() {
     #("exclaim", exclaim_template),
   ])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("Hello Oliver!")
 }

--- a/test/api_tests/property_test.gleam
+++ b/test/api_tests/property_test.gleam
@@ -1,4 +1,4 @@
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles
 import handles/ctx
@@ -8,7 +8,7 @@ pub fn property_string_test() {
   |> should.be_ok
   |> handles.run(ctx.Dict([ctx.Prop("name", ctx.Str("Oliver"))]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("Hello Oliver!")
 }
 
@@ -17,7 +17,7 @@ pub fn property_int_test() {
   |> should.be_ok
   |> handles.run(ctx.Dict([ctx.Prop("answer", ctx.Int(42))]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("The answer is 42!")
 }
 
@@ -26,6 +26,6 @@ pub fn property_float_test() {
   |> should.be_ok
   |> handles.run(ctx.Dict([ctx.Prop("pi", ctx.Float(3.14))]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("π = 3.14!")
 }

--- a/test/api_tests/unless_test.gleam
+++ b/test/api_tests/unless_test.gleam
@@ -1,4 +1,4 @@
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles
 import handles/ctx
@@ -8,7 +8,7 @@ pub fn unless_truthy_test() {
   |> should.be_ok
   |> handles.run(ctx.Dict([ctx.Prop("prop", ctx.Bool(True))]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("")
 }
 
@@ -17,7 +17,7 @@ pub fn unless_falsy_test() {
   |> should.be_ok
   |> handles.run(ctx.Dict([ctx.Prop("prop", ctx.Bool(False))]), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("yes")
 }
 
@@ -26,6 +26,6 @@ pub fn unless_current_context_test() {
   |> should.be_ok
   |> handles.run(ctx.Bool(False), [])
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("yes")
 }

--- a/test/unit_tests/ctx_test.gleam
+++ b/test/unit_tests/ctx_test.gleam
@@ -1,4 +1,4 @@
-import gleam/iterator
+import gleam/yielder
 import gleeunit/should
 import handles/ctx
 import handles/internal/ctx_utils
@@ -21,9 +21,9 @@ pub fn drill_shallow_test() {
 
 pub fn drill_deep_test() {
   let depth = 10_000
-  iterator.repeat("prop")
-  |> iterator.take(depth)
-  |> iterator.to_list
+  yielder.repeat("prop")
+  |> yielder.take(depth)
+  |> yielder.to_list
   |> ctx_utils.get(gen_levels(depth, ctx.Str(expected_string)), 0)
   |> should.be_ok
   |> should.equal(ctx.Str(expected_string))

--- a/test/unit_tests/engine_test.gleam
+++ b/test/unit_tests/engine_test.gleam
@@ -1,5 +1,5 @@
 import gleam/dict
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles/ctx
 import handles/internal/block
@@ -10,7 +10,7 @@ pub fn hello_world_test() {
   [parser.Constant(0, "Hello World")]
   |> engine.run(ctx.Dict([]), dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("Hello World")
 }
 
@@ -18,7 +18,7 @@ pub fn hello_name_test() {
   [parser.Constant(0, "Hello "), parser.Property(0, ["name"])]
   |> engine.run(ctx.Dict([ctx.Prop("name", ctx.Str("Oliver"))]), dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("Hello Oliver")
 }
 
@@ -26,7 +26,7 @@ pub fn self_tag_test() {
   [parser.Property(0, [])]
   |> engine.run(ctx.Str("Hello"), dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("Hello")
 }
 
@@ -37,7 +37,7 @@ pub fn nested_property_test() {
     dict.new(),
   )
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("42")
 }
 
@@ -51,7 +51,7 @@ pub fn truthy_if_test() {
     dict.new(),
   )
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("42")
 }
 
@@ -59,7 +59,7 @@ pub fn falsy_if_test() {
   [parser.Block(0, 0, block.If, ["bool"], [parser.Property(0, ["foo", "bar"])])]
   |> engine.run(ctx.Dict([ctx.Prop("bool", ctx.Bool(False))]), dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("")
 }
 
@@ -71,7 +71,7 @@ pub fn truthy_unless_test() {
   ]
   |> engine.run(ctx.Dict([ctx.Prop("bool", ctx.Bool(True))]), dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("")
 }
 
@@ -89,7 +89,7 @@ pub fn falsy_unless_test() {
     dict.new(),
   )
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("42")
 }
 
@@ -116,7 +116,7 @@ pub fn each_test() {
     dict.new(),
   )
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("They are Knatte, Fnatte, Tjatte, and Kalle")
 }
 
@@ -129,6 +129,6 @@ pub fn empty_each_test() {
   ]
   |> engine.run(ctx.Dict([ctx.Prop("list", ctx.List([]))]), dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal("")
 }

--- a/test/user_stories/big_template.gleam
+++ b/test/user_stories/big_template.gleam
@@ -1,5 +1,5 @@
 import gleam/dict
-import gleam/iterator
+import gleam/yielder
 import gleeunit/should
 import handles/ctx
 import handles/internal/engine
@@ -21,20 +21,28 @@ const input_context = ctx.Dict(
   ],
 )
 
-fn generate_template(size: Int, sep: String) {
-  iterator.repeat("{{#each knattarna}}{{name}}, {{/each}}")
-  |> iterator.take(size)
-  |> iterator.fold("", fn(a, b) { a <> sep <> b })
+pub type TestSpec(a) {
+  Timeout(Int, fn() -> a)
 }
 
-pub fn tokenizer_test() {
+fn generate_template(size: Int, sep: String) {
+  yielder.repeat("{{#each knattarna}}{{name}}, {{/each}}")
+  |> yielder.take(size)
+  |> yielder.fold("", fn(a, b) { a <> sep <> b })
+}
+
+pub fn tokenizer_test_() {
+  use <- Timeout(10)
+
   let big_template = generate_template(10_000, " ")
 
   tokenizer.run(big_template)
   |> should.be_ok
 }
 
-pub fn parser_test() {
+pub fn parser_test_() {
+  use <- Timeout(10)
+
   let big_template = generate_template(10_000, " ")
 
   tokenizer.run(big_template)
@@ -43,7 +51,9 @@ pub fn parser_test() {
   |> should.be_ok
 }
 
-pub fn engine_test() {
+pub fn engine_test_() {
+  use <- Timeout(10)
+
   let big_template = generate_template(10_000, " ")
 
   tokenizer.run(big_template)

--- a/test/user_stories/hello_test.gleam
+++ b/test/user_stories/hello_test.gleam
@@ -1,5 +1,5 @@
 import gleam/dict
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles/ctx
 import handles/internal/engine
@@ -11,12 +11,14 @@ const input_template = "Hello {{name}}!"
 const input_context = ctx.Dict([ctx.Prop("name", ctx.Str("Oliver"))])
 
 const expected_tokens = [
-  tokenizer.Constant(0, "Hello "), tokenizer.Property(8, ["name"]),
+  tokenizer.Constant(0, "Hello "),
+  tokenizer.Property(8, ["name"]),
   tokenizer.Constant(14, "!"),
 ]
 
 const expected_ast = [
-  parser.Constant(0, "Hello "), parser.Property(8, ["name"]),
+  parser.Constant(0, "Hello "),
+  parser.Property(8, ["name"]),
   parser.Constant(14, "!"),
 ]
 
@@ -37,6 +39,6 @@ pub fn parser_test() {
 pub fn engine_test() {
   engine.run(expected_ast, input_context, dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal(expected_output)
 }

--- a/test/user_stories/knattarna_test.gleam
+++ b/test/user_stories/knattarna_test.gleam
@@ -1,5 +1,5 @@
 import gleam/dict
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles/ctx
 import handles/internal/block
@@ -27,8 +27,10 @@ const input_context = ctx.Dict(
 const expected_tokens = [
   tokenizer.Constant(0, "They are "),
   tokenizer.BlockStart(11, block.Each, ["knattarna"]),
-  tokenizer.Property(30, ["name"]), tokenizer.Constant(36, ", "),
-  tokenizer.BlockEnd(40, block.Each), tokenizer.Constant(47, "and Kalle"),
+  tokenizer.Property(30, ["name"]),
+  tokenizer.Constant(36, ", "),
+  tokenizer.BlockEnd(40, block.Each),
+  tokenizer.Constant(47, "and Kalle"),
 ]
 
 const expected_ast = [
@@ -39,7 +41,8 @@ const expected_ast = [
     block.Each,
     ["knattarna"],
     [parser.Property(30, ["name"]), parser.Constant(36, ", ")],
-  ), parser.Constant(47, "and Kalle"),
+  ),
+  parser.Constant(47, "and Kalle"),
 ]
 
 const expected_output = "They are Knatte, Fnatte, Tjatte, and Kalle"
@@ -59,6 +62,6 @@ pub fn parser_test() {
 pub fn engine_test() {
   engine.run(expected_ast, input_context, dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal(expected_output)
 }

--- a/test/user_stories/nested_block_test.gleam
+++ b/test/user_stories/nested_block_test.gleam
@@ -1,5 +1,5 @@
 import gleam/dict
-import gleam/string_builder
+import gleam/string_tree
 import gleeunit/should
 import handles/ctx
 import handles/internal/block
@@ -50,7 +50,8 @@ const input_context = ctx.Dict(
 const expected_tokens = [
   tokenizer.BlockStart(2, block.Each, ["outer"]),
   tokenizer.BlockStart(17, block.Each, ["inner"]),
-  tokenizer.Property(32, ["value"]), tokenizer.BlockEnd(41, block.Each),
+  tokenizer.Property(32, ["value"]),
+  tokenizer.BlockEnd(41, block.Each),
   tokenizer.BlockEnd(50, block.Each),
 ]
 
@@ -89,6 +90,6 @@ pub fn parser_test() {
 pub fn engine_test() {
   engine.run(expected_ast, input_context, dict.new())
   |> should.be_ok
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> should.equal(expected_output)
 }


### PR DESCRIPTION
Starting with gleam/stdlib version 0.48.0 some of the functions used by handles were removed.
This means that handles can currently only be used with versions up to 0.47.0.

I updated the stdlib version to the lowest one that started to remove the functions and updated the code to use the recommended replacements. I tested that this works with stdlib version 0.56.0 (the latest version rn). 

As this is a breaking change (all usages must update to stdlib versions >= 0.48.0) I bumped the version to 5.0.0.